### PR TITLE
Remove UTF-8 handling. It wasn't actually needed

### DIFF
--- a/aerialbot.py
+++ b/aerialbot.py
@@ -1159,7 +1159,7 @@ def main():
     if args.direction_cli:
         direction_cli = args.direction_cli
     if 'MASTODON' in config and args.text_cli:
-        toot_text = bytes(args.text_cli, "utf-8").decode("unicode_escape")
+        toot_text = args.text_cli
 
     ############################################################################
 


### PR DESCRIPTION
Due to a mix of UTF-8 characters and URL-encoded characters I was using in my toot texts on the command line, I thought I had to do some fancy decoding work. It turns out that I didn't.